### PR TITLE
Post Clopen Winterval changes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,4 +7,4 @@ defaults:
     scope:
       path: "" # an empty string here means all files in the project
     values:
-      layout: "winter"
+      layout: "default"

--- a/_layouts/backstage.html
+++ b/_layouts/backstage.html
@@ -11,7 +11,6 @@
 #snow {z-index:2!important}
 </style>
 <body>
-{% include _snow.html %}
 {% include _header.html %}
 
 <!-- MAIN CONTENT -->

--- a/events/index.md
+++ b/events/index.md
@@ -3,7 +3,7 @@ title: "Events"
 permalink: /events
 ---
 
-**Clopen Mic Night #2: Clopen Winterval** took place on **Thursday 20th January** from **8-9pm** (UK time). A recording of the show can be watched on YouTube at [youtu.be/OyBScjWS4Ns](https://youtu.be/OyBScjWS4Ns) until 20th February.
+**Clopen Mic Night #2: Clopen Winterval** took place on **Thursday 20th January** from **8-9pm** (UK time). A recording of the show was available to watch until 20th February.
 The line-up for Clopen Mic Night #2 can be found on [the events page](events/index.md).
 
 The show is free to watch, but we support our performers and pay our behind-the-scenes team 

--- a/index.md
+++ b/index.md
@@ -8,8 +8,8 @@ mathematicians, performers and maths communicators bringing you a
 random<a href='#footnote2'>**</a> selection of comedy, music, art, demos and puzzles to
 share and showcase their love of mathematics.
 
-**Clopen Mic Night #2: Clopen Winterval** took place on **Thursday 20th January** from **8-9pm** (UK time). A recording of the show can be watched on YouTube at [youtu.be/OyBScjWS4Ns](https://youtu.be/OyBScjWS4Ns) until 20th February.
-The line-up for Clopen Mic Night #2 can be found on [the events page](events/index.md).
+**Clopen Mic Night #2: Clopen Winterval** took place on **Thursday 20th January** from **8-9pm** (UK time). A recording of the show
+was available to watch until 20th February. The line-up for Clopen Mic Night #2 can be found on [the events page](events/index.md).
 
 Clopen Mic Night happens on a semi-regular basis, live on YouTube, with audience interaction in the YouTube Live Chat and a selection of four 
 acts to enjoy. The [first Clopen Mic Night](events/2021-08-26.md) took place as part of the 2021 Talking Maths in 


### PR DESCRIPTION
Remove link to Clopen Mic Night 2 video.

Remove snow from all pages except the Clopen Mic Night 2 page.

This should be merged next Monday once the video recording is gone.